### PR TITLE
Update README.md: Two reference parpers added at Geometric Deep Learning/Theory/

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ This is a collaborative work-in-progress. Please contribute via PRs!
 * [**The Riemannian Geometry of Deep Generative Models** (2018) <br /> *Hang Shao, Abhishek Kumar, P. Thomas Fletcher* <br /> <img src="https://img.shields.io/badge/-differential geometry-A8E6CE" />](https://drive.google.com/file/d/1Nxq-lLG1txHy6cYjOM3fMM3D5yIZx6hd/view?usp=sharing)
 * [**Universal Approximation Theorems for Differentiable Geometric Deep Learning** (2022)  <br /> *Anastasis Kratsios, L´eonie Papon* <br /> <img src="https://img.shields.io/badge/-differential geometry-A8E6CE" />
 ](https://www.jmlr.org/papers/volume23/21-0716/21-0716.pdf)
+* [**Regularized Autoencoders for Isometric Representation Learning** (2022)  <br /> *Yonghyeon Lee, Sangwoong Yoon, Minjun Son, Frank C. Park* <br /> <img src="https://img.shields.io/badge/-differential geometry-A8E6CE" />
+](https://drive.google.com/file/d/1XFdHcPMFDFF-7H10LwLg7N_6d0_cIJmE/view)
+* [**A Statistical Manifold Framework for Point Cloud Data** (2022)  <br /> *Yonghyeon Lee, Seungyeon Kim, Jinwon Choi, Frank C. Park* <br /> <img src="https://img.shields.io/badge/-differential geometry-A8E6CE" />
+](https://drive.google.com/file/d/1SynnbbJH7NSP_TaYDwsSH5QMUJK1YzSA/view)
 
 <a name="equivariance" />
 


### PR DESCRIPTION
I request to add two relevant papers where Riemannian geometric methods are used in deep learning contexts.

Specifically, 
1. "Regularized Autoencoders for Isometric Representation Learning" is based on the theory of mappings between two Riemannian manifolds (e.g., isometry, conformal maps, etc.), 
2. "A Statistical Manifold Framework for Point Cloud Data" is based on the theory of statistical manifold in information geometry.

Riemannian geometric concepts are employed for autoencoder applications.

